### PR TITLE
对PhigrosLibrary.py一些小问题的改动

### DIFF
--- a/py/PhigrosLibrary.py
+++ b/py/PhigrosLibrary.py
@@ -98,10 +98,10 @@ class B19Class:
     
     def read_difficulty(self, path):
         difficulty.clear()
-        with open(path) as f:
+        with open(path,encoding="UTF-8") as f:
             lines = f.readlines()
         for line in lines:
-            line = line[:-1].split("\\")
+            line = line[:-1].split(",")
             diff = []
             for i in range(1, len(line)):
                 diff.append(float(line[i]))


### PR DESCRIPTION
发现读取定数表的时候似乎默认使用gbk，会报错
![屏幕截图 2023-12-23 004804](https://github.com/7aGiven/PhigrosLibrary/assets/94744411/74a45564-e410-4d1c-904e-8c811eba0ee1)

以及分隔符似乎有点问题，读取到的定数表就成了这样
![屏幕截图 2023-12-23 004528](https://github.com/7aGiven/PhigrosLibrary/assets/94744411/9392b501-9ae5-4f76-9b32-fb08d4bdb63f)
然后就又报错了
![屏幕截图 2023-12-23 005020](https://github.com/7aGiven/PhigrosLibrary/assets/94744411/3c287e6f-3670-4dca-a626-0de19855dbf4)

所以在第101行加了个encoding="UTF-8"，104行的"\\"换成了","
墓前运作正常
![image](https://github.com/7aGiven/PhigrosLibrary/assets/94744411/8808d5b1-11a9-4e60-bb49-01dc0a5f91c6)
